### PR TITLE
Add startup script oloscreen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ cd backend
 ```
 ## Usage
 Change directory back to project root of the project. Opening tmux or screen might help here.
-Run these commands:
-```npm start```
+### Startup script
+There's a startup script that starts the commands described below under manual starting.
+In project folder run:
+```
+./oloscreen.sh
+```
+### Manual startup
+If `./oloscreen.sh` doesn't work, you can try starting everything manually:
+```
+npm start
+```
 And then
-```cd backend```
+```
+cd backend
+```
 On backend run
 ```
 ./start.sh

--- a/oloscreen.sh
+++ b/oloscreen.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd ~/oloscreen-v2/
+npm start &
+cd backend
+./start.sh &
+source venv/bin/activate
+python3 telegram-bot.py


### PR DESCRIPTION
This bash script starts development web server and backend services:
menuproxy.py (via backend/start.sh)
telegram-bot.py

Development server should not be used in production -> needs to be changed when possible