### PR TITLE
Handle cases when sodexo is closed

### DIFF
--- a/backend/menuproxy.py
+++ b/backend/menuproxy.py
@@ -54,7 +54,7 @@ def restaurants():
 
     data = {"sodexo": {}}
     print("tässä", get_json(sodexo_opening_hours)[0]['openingHours'])
-    data['sodexo']['menus'] = get_json(sodexo_menu.format(timestamp))[sodexo_id][today.strftime("%Y-%m-%d")]
+    data['sodexo']['menus'] = get_json(sodexo_menu.format(timestamp))[sodexo_id].get(today.strftime("%Y-%m-%d"), [])
     data['sodexo']['openingHours'] =  get_json(sodexo_opening_hours)[0]['openingHours']
     data['amica'] = get_json(amica_url + amica_timestamp)
     # subway disabled for now


### PR DESCRIPTION
Previously menuproxy returned internal server error when sodexo was closed and didn't have any menus. This PR adds handling for those cases so that the menuproxy just returns an empty list of menus. The frontend will render it correctly. 