### PR TITLE
Add link to Telegram bot

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,16 @@ body {
   padding-top: 10px;
   font-family: 'Open Sans';
 }
+
+a, a:visited {
+  color: white;
+  text-decoration: none;
+  font-weight: bold;
+}
+a:hover {
+  text-decoration: underline;
+}
+
 .courses {
   max-width: 50%;
   margin-left: 30px;

--- a/src/components/ShoutboxComponent.js
+++ b/src/components/ShoutboxComponent.js
@@ -27,7 +27,11 @@ class SponsorComponent extends Component {
         return (
             <div id="shouts">
                 <h1>HUUTOLOOTA</h1>
-                <h4> TG: @OloscreenBot</h4>
+                <h4>TG:
+                  <a target="_blank" href="https://t.me/oloscreenbot">
+                    @OloscreenBot
+                  </a>
+                </h4>
                 {shouts.map(shout =>
                     <div>{shout}</div>)}
 


### PR DESCRIPTION
Additionally, add basic styling for links.

This isn't useful in the guild room display, but it might be nice for users who access the service on their own devices.